### PR TITLE
display address on ledger when calling `getaddress`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "icebox"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icebox"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 
 [lib]

--- a/src/dongle/message.rs
+++ b/src/dongle/message.rs
@@ -167,18 +167,20 @@ pub struct GetWalletPublicKey<'a> {
     reply: Vec<u8>,
     sw: u16,
     bip32_path: &'a [u32],
+    display: bool
 }
 
 impl<'a> GetWalletPublicKey<'a> {
     /// Constructor
-    pub fn new(bip32_path: &'a [u32]) -> GetWalletPublicKey {
+    pub fn new(bip32_path: &'a [u32], display: bool) -> GetWalletPublicKey {
         assert!(bip32_path.len() < 11);  // limitation of the Nano S
 
         GetWalletPublicKey {
             sent: false,
             reply: vec![],
             sw: 0,
-            bip32_path: bip32_path
+            bip32_path: bip32_path,
+            display: display
         }
     }
 }
@@ -193,7 +195,7 @@ impl<'a> Command for GetWalletPublicKey<'a> {
         let mut ret = Vec::with_capacity(5 + 4 * self.bip32_path.len());
         ret.push(apdu::ledger::BTCHIP_CLA);
         ret.push(apdu::ledger::ins::GET_WALLET_PUBLIC_KEY);
-        ret.push(0);
+        ret.push(if self.display {1} else {0});
         ret.push(0);
         ret.push((1 + 4 * self.bip32_path.len()) as u8);
         ret.push(self.bip32_path.len() as u8);

--- a/src/dongle/mod.rs
+++ b/src/dongle/mod.rs
@@ -50,8 +50,8 @@ pub trait Dongle {
     }
 
     /// Queries the device for a BIP32 extended pubkey
-    fn get_public_key(&mut self, bip32_path: &[u32]) -> Result<message::WalletPublicKey, Error> {
-        let command = message::GetWalletPublicKey::new(bip32_path);;
+    fn get_public_key(&mut self, bip32_path: &[u32], display: bool) -> Result<message::WalletPublicKey, Error> {
+        let command = message::GetWalletPublicKey::new(bip32_path, display);
         let (sw, rev) = try!(self.exchange(command));
         if sw == constants::apdu::ledger::sw::OK {
             message::WalletPublicKey::decode(&rev)

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,12 +203,16 @@ fn main() {
                     let entry = pretty_unwrap("Searching for entry",
                                               wallet.search(&mut dongle, &args[3]));
                     println!("{}", entry);
+                    pretty_unwrap("Confirming address",
+                                  wallet.display(&mut dongle, entry.index));
                 } else {
                 // Otherwise take the index as an index
                     let index = usize::from_str(&args[3]).expect("Parsing index as number");
                     let entry = pretty_unwrap("Decrypting entry",
                                               wallet.lookup(&mut dongle, index));
                     println!("{}", entry);
+                    pretty_unwrap("Confirming address",
+                                  wallet.display(&mut dongle, entry.index));
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,8 @@ fn main() {
                 let entry = pretty_unwrap("Updating entry",
                                           wallet.update(&mut dongle, index, name, block, Update::Unused(note)));
                 println!("{}", entry);
+                pretty_unwrap("Confirming address",
+                              wallet.display(&mut dongle, index));
                 println!("Rerandomizing wallet...");
                 pretty_unwrap("Rerandomizing wallet",
                               wallet.rerandomize(&mut dongle));

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -223,7 +223,7 @@ impl EncryptedWallet {
     }
 
     /// Display an address on the Ledger screen and make the user click "confirm"
-    pub fn display<'a, D: Dongle>(&mut self, dongle: &mut D, index: usize) -> Result<(), Error> {
+    pub fn display<'a, D: Dongle>(&self, dongle: &mut D, index: usize) -> Result<(), Error> {
         let path = bip32_path(self.network, self.account, KeyPurpose::Address, index as u32);
         dongle.get_public_key(&path, true)?;
         Ok(())


### PR DESCRIPTION
Removes addresses from console display. Shows it on the Ledger device during "info" and "getaddress" calls instead, requiring the user to click "Confirm" and removing a trust vector from the user's terminal.

Fixes #1