### PR TITLE
Fix up command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ You'll see that each descriptor has an index, which is used to identify it in
 the wallet. When there is only one descriptor it will have index 0. You can
 get a new address from it by running
 
-    icboc3d wallet.icboc.dat getnewaddress '{ "descriptor": 0 }'
+    icboc3d wallet.icboc.dat getnewaddress '{ "descriptor": 0, "note": "initial wallet funds" }'
+
+The `note` field can be set to any string you want.
 
 Then receive coins either by copying raw transactions and running
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -107,8 +107,8 @@ macro_rules! register_commands {
 }
 
 register_commands! {
-    getnewaddress, GetNewAddress, "{ \"descriptor\": int, \"index\": int }";
-    init, Init, "{ \"force\": bool }";
+    getnewaddress, GetNewAddress, "{ \"descriptor\": int, \"note\": string, \"index\": int (optional) }";
+    init, Init, "{ \"force\": bool (optional) }";
     info, Info, "";
     listunspent, ListUnspent, "";
     importdescriptor, ImportDescriptor, "{ \"desc\": string, \"range_low\": int, \"range_high\": int }";


### PR DESCRIPTION
The getnewaddress requires a note field.

Mark a few fields that I know are optional as optional.

Fixes #12.