### PR TITLE
fix `info` command with no arguments

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -28,10 +28,13 @@ pub struct Info;
 /// Gets information
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Options {}
+pub struct Options {
+    #[serde(default)]
+    _dummy: (),
+}
 
 impl super::Command for Info {
-    type Options = ();
+    type Options = Options;
 
     fn execute<D: Dongle, P: AsRef<Path>>(
         _: Self::Options,


### PR DESCRIPTION
This is not a very clean fix -- but I would like to rewrite option parsing entirely, and in the current "provide a JSON blob with empty string interpreted as {}" paradigm, this is the simplest fix.