### PR TITLE
Update bitcoin dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,21 +16,31 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
+version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
 name = "bitcoin"
-version = "0.30.2"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
+checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "bech32",
- "bitcoin-private",
- "bitcoin_hashes",
+ "bitcoin-internals",
+ "bitcoin_hashes 0.13.0",
+ "hex-conservative",
  "hex_lit",
  "secp256k1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+dependencies = [
  "serde",
 ]
 
@@ -47,6 +57,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
  "serde",
 ]
 
@@ -61,6 +81,12 @@ name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex_lit"
@@ -130,12 +156,13 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "miniscript"
-version = "10.2.0"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d371924f9eb7aa860ab395baaaa0bcdfa81a32f330b538c4e2c04617b2722fe3"
+checksum = "3127e10529a57a8f7fa9b1332c4c2f72baadaca6777798f910dff3c922620b14"
 dependencies = [
+ "bech32",
  "bitcoin",
- "bitcoin-private",
+ "bitcoin-internals",
  "serde",
 ]
 
@@ -171,20 +198,20 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.12.0",
  "secp256k1-sys",
  "serde",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,22 +22,31 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitcoin"
-version = "0.29.2"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
+checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
 dependencies = [
  "bech32",
+ "bitcoin-private",
  "bitcoin_hashes",
+ "hex_lit",
  "secp256k1",
  "serde",
 ]
 
 [[package]]
-name = "bitcoin_hashes"
-version = "0.11.0"
+name = "bitcoin-private"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
+ "bitcoin-private",
  "serde",
 ]
 
@@ -52,6 +61,12 @@ name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "hidapi"
@@ -115,11 +130,12 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "miniscript"
-version = "9.0.0"
+version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123a10aae81d0712ecc09b780f6f0ae0b0f506a5c4c912974725760d59ba073e"
+checksum = "d371924f9eb7aa860ab395baaaa0bcdfa81a32f330b538c4e2c04617b2722fe3"
 dependencies = [
  "bitcoin",
+ "bitcoin-private",
  "serde",
 ]
 
@@ -155,9 +171,9 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "secp256k1"
-version = "0.24.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes",
  "secp256k1-sys",
@@ -166,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.6.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "jsonrpc"
-version = "0.14.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248ea3eab5d9a37ee324b1f576f19d274ff7e56cd5206ea4755a7ef918e94fa4"
+checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,12 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,7 +159,6 @@ name = "icboc"
 version = "3.0.0"
 dependencies = [
  "anyhow",
- "byteorder",
  "hidapi",
  "home",
  "jsonrpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,20 +32,23 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bech32"
-version = "0.10.0-beta"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitcoin"
-version = "0.31.2"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
+ "base58ck",
  "bech32",
- "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
- "hex-conservative",
+ "bitcoin-internals 0.3.0",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
  "hex_lit",
  "secp256k1",
  "serde",
@@ -40,23 +59,30 @@ name = "bitcoin-internals"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "bitcoin-private"
-version = "0.1.0"
+name = "bitcoin-io"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
 
 [[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
+name = "bitcoin-units"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
- "bitcoin-private",
+ "bitcoin-internals 0.3.0",
+ "serde",
 ]
 
 [[package]]
@@ -65,8 +91,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
- "hex-conservative",
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
  "serde",
 ]
 
@@ -87,6 +123,15 @@ name = "hex-conservative"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hex_lit"
@@ -156,13 +201,12 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "miniscript"
-version = "11.2.0"
+version = "12.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3127e10529a57a8f7fa9b1332c4c2f72baadaca6777798f910dff3c922620b14"
+checksum = "5bd3c9608217b0d6fa9c9c8ddd875b85ab72bd4311cfc8db35e1b5a08fc11f4d"
 dependencies = [
  "bech32",
  "bitcoin",
- "bitcoin-internals",
  "serde",
 ]
 
@@ -198,20 +242,20 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.13.0",
  "secp256k1-sys",
  "serde",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.0"
 jsonrpc = { version ="0.18", optional = true }
 hidapi = "2.0"
 home = "0.5"
-miniscript = { version = "9.0", features = [ "serde" ] }
+miniscript = { version = "10.0", features = [ "serde" ] }
 thiserror = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,15 @@ path = "src/lib/lib.rs"
 name = "icboc3d"
 path = "src/main.rs"
 
+[features]
+jsonrpc = [ "dep:jsonrpc", "dep:home" ]
+
 [dependencies]
 anyhow = "1.0"
 byteorder = "1.0"
 jsonrpc = { version ="0.18", optional = true }
 hidapi = "2.0"
-home = "0.5"
+home = { version = "0.5", optional = true }
 miniscript = { version = "12.3", features = [ "serde" ] }
 thiserror = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.0"
 jsonrpc = { version ="0.18", optional = true }
 hidapi = "2.0"
 home = "0.5"
-miniscript = { version = "11.0", features = [ "serde" ] }
+miniscript = { version = "12.3", features = [ "serde" ] }
 thiserror = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.0"
 jsonrpc = { version ="0.18", optional = true }
 hidapi = "2.0"
 home = "0.5"
-miniscript = { version = "10.0", features = [ "serde" ] }
+miniscript = { version = "11.0", features = [ "serde" ] }
 thiserror = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ jsonrpc = [ "dep:jsonrpc", "dep:home" ]
 
 [dependencies]
 anyhow = "1.0"
-byteorder = "1.0"
 jsonrpc = { version ="0.18", optional = true }
 hidapi = "2.0"
 home = { version = "0.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 byteorder = "1.0"
-jsonrpc = { version ="0.14", optional = true }
+jsonrpc = { version ="0.18", optional = true }
 hidapi = "2.0"
 home = "0.5"
 miniscript = { version = "9.0", features = [ "serde" ] }

--- a/src/commands/importicboc/mod.rs
+++ b/src/commands/importicboc/mod.rs
@@ -21,7 +21,7 @@ mod aes;
 
 use anyhow::{self, Context};
 use icboc::Dongle;
-use miniscript::bitcoin::util::bip32;
+use miniscript::bitcoin::bip32;
 use serde::Deserialize;
 use std::{
     fs,

--- a/src/commands/importicboc/mod.rs
+++ b/src/commands/importicboc/mod.rs
@@ -133,7 +133,8 @@ impl super::Command for ImportIcboc {
                     false,
                 )?
                 .chain_code;
-            let decrypted_entry = self::aes::aes256_decrypt_ctr(encryption_key, iv, entry);
+            let decrypted_entry =
+                self::aes::aes256_decrypt_ctr(encryption_key.to_bytes(), iv, entry);
 
             if decrypted_entry != [0; DECRYPTED_ENTRY_SIZE] {
                 let time = String::from_utf8(decrypted_entry[164..188].to_owned())

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -44,13 +44,13 @@ impl super::Command for Info {
         let (key, _) = super::get_wallet_key_and_nonce(dongle)?;
         let wallet = super::open_wallet(&mut *dongle, &wallet_path, key)?;
 
-        let mut full_balance = 0;
+        let mut full_balance = bitcoin::Amount::ZERO;
         if wallet.n_descriptors() > 0 {
             println!("Descriptors:");
             for desc in wallet.descriptors() {
                 let txos = wallet.txos_for(desc.wallet_idx);
                 let mut n_spent = 0;
-                let mut balance = 0;
+                let mut balance = bitcoin::Amount::ZERO;
                 for txo in &txos {
                     if txo.spent_data.is_some() {
                         n_spent += 1;
@@ -61,7 +61,7 @@ impl super::Command for Info {
                 println!("  {:4} {}", desc.wallet_idx, desc.desc);
                 println!("       Range: {}-{}", desc.low, desc.high - 1);
                 println!("       TXOs: {} total, {} spent", txos.len(), n_spent);
-                println!("       Balance: {}", bitcoin::Amount::from_sat(balance));
+                println!("       Balance: {}", balance);
                 println!();
                 full_balance += balance;
             }
@@ -75,10 +75,7 @@ impl super::Command for Info {
             println!();
         }
         println!("Last rescan to: {}.", wallet.block_height());
-        println!(
-            "Wallet balance: {}",
-            bitcoin::Amount::from_sat(full_balance)
-        );
+        println!("Wallet balance: {}", full_balance);
         println!();
 
         Ok(())

--- a/src/commands/listunspent.rs
+++ b/src/commands/listunspent.rs
@@ -51,14 +51,14 @@ impl super::Command for ListUnspent {
             .iter()
             .filter(|txo| txo.spent_data.is_none())
             .map(|txo| txo.value)
-            .sum::<u64>();
+            .sum::<bitcoin::Amount>();
 
         for txo in all_txos {
             if options.show_all || txo.spent_data.is_none() {
                 println!("{}", txo);
             }
         }
-        println!("Total balance: {}", bitcoin::Amount::from_sat(full_balance));
+        println!("Total balance: {}", full_balance);
         println!();
 
         Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,8 +30,8 @@ mod signrawtransaction;
 use anyhow::{self, Context};
 use icboc::{Dongle, Wallet};
 use miniscript::bitcoin::{
+    bip32,
     hashes::{sha256, Hash},
-    util::bip32,
 };
 use serde::de::DeserializeOwned;
 use std::{borrow::Cow, env, fs, path::Path};
@@ -141,7 +141,7 @@ fn get_wallet_key_and_nonce<D: Dongle>(dongle: &mut D) -> anyhow::Result<([u8; 3
     let sig = dongle
         .sign_message(&KEYSIG_MESSAGE, &KEYSIG_PATH)
         .context("getting encryption key-signature from device")?;
-    let wallet_key = sha256::Hash::hash(&sig.serialize_compact()).into_inner();
+    let wallet_key = sha256::Hash::hash(&sig.serialize_compact()).to_byte_array();
     let wallet_nonce = dongle
         .get_random_nonce()
         .context("getting random encryption IV from device")?;

--- a/src/commands/receive.rs
+++ b/src/commands/receive.rs
@@ -49,7 +49,7 @@ impl super::Command for Receive {
         let tx: bitcoin::Transaction =
             consensus::deserialize(&rawtx).context("decoding raw transaction")?;
 
-        println!("Scanning tx {}", tx.txid());
+        println!("Scanning tx {}", tx.compute_txid());
         let (received, spent) = wallet.scan_tx(&tx, 0);
         for txo in spent {
             println!("spent {}", txo);
@@ -59,7 +59,7 @@ impl super::Command for Receive {
         }
 
         super::save_wallet(&wallet, &wallet_path, key, nonce)
-            .with_context(|| format!("saving wallet at after receive of {}", tx.txid()))?;
+            .with_context(|| format!("saving wallet at after receive of {}", tx.compute_txid()))?;
 
         Ok(())
     }

--- a/src/lib/dongle/message.rs
+++ b/src/lib/dongle/message.rs
@@ -20,7 +20,7 @@
 
 use byteorder::{BigEndian, WriteBytesExt};
 use miniscript::bitcoin;
-use miniscript::bitcoin::util::bip32;
+use miniscript::bitcoin::bip32;
 use std::cmp;
 
 use crate::constants::apdu::ledger::{self, Instruction};
@@ -694,7 +694,7 @@ pub struct UntrustedHashSign<'a> {
     reply: Vec<u8>,
     sw: u16,
     bip32_path: &'a [bip32::ChildNumber],
-    sighash: bitcoin::EcdsaSighashType,
+    sighash: bitcoin::sighash::EcdsaSighashType,
     tx_locktime: u32,
 }
 
@@ -702,7 +702,7 @@ impl<'a> UntrustedHashSign<'a> {
     /// Constructor
     pub fn new<P: AsRef<[bip32::ChildNumber]>>(
         bip32_path: &'a P,
-        sighash: bitcoin::EcdsaSighashType,
+        sighash: bitcoin::sighash::EcdsaSighashType,
         tx_locktime: u32,
     ) -> Self {
         UntrustedHashSign {

--- a/src/lib/dongle/mod.rs
+++ b/src/lib/dongle/mod.rs
@@ -168,9 +168,9 @@ pub trait Dongle {
     }
 
     /// Gets the BIP32 fingerprint of the device's master key
-    fn get_master_xpub(&mut self) -> Result<bip32::ExtendedPubKey, Error> {
+    fn get_master_xpub(&mut self) -> Result<bip32::Xpub, Error> {
         let master_wpk = self.get_public_key(&[], false)?;
-        let master_xpub = bip32::ExtendedPubKey {
+        let master_xpub = bip32::Xpub {
             network: bitcoin::Network::Bitcoin,
             depth: 0,
             parent_fingerprint: bip32::Fingerprint::default(),

--- a/src/lib/dongle/mod.rs
+++ b/src/lib/dongle/mod.rs
@@ -17,8 +17,8 @@
 //! Abstract API for communicating with the device
 //!
 
+use miniscript::bitcoin::bip32;
 use miniscript::bitcoin::secp256k1::{self, ecdsa};
-use miniscript::bitcoin::util::bip32;
 use miniscript::{self, bitcoin};
 
 use self::message::{Command, Response};
@@ -39,14 +39,14 @@ pub struct TrustedInput {
     /// `get_trusted_input` call
     blob: [u8; 56],
     /// `ScriptPubKey` of the output being spent
-    script_pubkey: bitcoin::Script,
+    script_pubkey: bitcoin::ScriptBuf,
 }
 
 impl Default for TrustedInput {
     fn default() -> Self {
         TrustedInput {
             blob: [0; 56],
-            script_pubkey: bitcoin::Script::new(),
+            script_pubkey: bitcoin::ScriptBuf::new(),
         }
     }
 }
@@ -125,7 +125,7 @@ pub trait Dongle {
                 }
 
                 let fingerprint = key.master_fingerprint();
-                let key_full_path = key.full_derivation_path();
+                let key_full_path = key.full_derivation_path().expect("no multipath keys");
                 assert!(key_full_path.len() < 11); // limitation of the Nano S
 
                 // Check for fingerprint mismatch
@@ -161,6 +161,9 @@ pub trait Dongle {
                 );
                 Ok(dongle_xpub.public_key)
             }
+            miniscript::DescriptorPublicKey::MultiXPub(..) => {
+                panic!("multipath keys (BIP 389) not supported")
+            }
         }
     }
 
@@ -173,7 +176,7 @@ pub trait Dongle {
             parent_fingerprint: bip32::Fingerprint::default(),
             child_number: bip32::ChildNumber::Normal { index: 0 },
             public_key: master_wpk.public_key,
-            chain_code: master_wpk.chain_code[..].into(),
+            chain_code: master_wpk.chain_code.into(),
         };
         Ok(master_xpub)
     }
@@ -301,7 +304,7 @@ pub trait Dongle {
     fn transaction_sign<P: AsRef<[bip32::ChildNumber]>>(
         &mut self,
         bip32_path: &P,
-        sighash: bitcoin::EcdsaSighashType,
+        sighash: bitcoin::sighash::EcdsaSighashType,
         tx_locktime: u32,
     ) -> Result<ecdsa::Signature, Error> {
         let command = message::UntrustedHashSign::new(bip32_path, sighash, tx_locktime);

--- a/src/lib/dongle/mod.rs
+++ b/src/lib/dongle/mod.rs
@@ -171,7 +171,7 @@ pub trait Dongle {
     fn get_master_xpub(&mut self) -> Result<bip32::Xpub, Error> {
         let master_wpk = self.get_public_key(&[], false)?;
         let master_xpub = bip32::Xpub {
-            network: bitcoin::Network::Bitcoin,
+            network: bitcoin::NetworkKind::Main,
             depth: 0,
             parent_fingerprint: bip32::Fingerprint::default(),
             child_number: bip32::ChildNumber::Normal { index: 0 },

--- a/src/lib/dongle/mod.rs
+++ b/src/lib/dongle/mod.rs
@@ -176,7 +176,7 @@ pub trait Dongle {
             parent_fingerprint: bip32::Fingerprint::default(),
             child_number: bip32::ChildNumber::Normal { index: 0 },
             public_key: master_wpk.public_key,
-            chain_code: master_wpk.chain_code.into(),
+            chain_code: master_wpk.chain_code,
         };
         Ok(master_xpub)
     }

--- a/src/lib/dongle/tx.rs
+++ b/src/lib/dongle/tx.rs
@@ -48,7 +48,10 @@ pub fn encode<T: Encodable>(
     piece_len: usize,
 ) -> Vec<u8> {
     // Compute the new object's length
-    let len = obj.consensus_encode(&mut io::sink()).unwrap();
+    // FIXME shouldn't need from_std; see https://github.com/rust-bitcoin/rust-bitcoin/issues/3788
+    let len = obj
+        .consensus_encode(&mut bitcoin::io::from_std(io::sink()))
+        .unwrap();
     // Start a new piece if necessary
     if current_piece.len() + len > piece_len {
         pieces.push(current_piece);

--- a/src/lib/dongle/tx.rs
+++ b/src/lib/dongle/tx.rs
@@ -110,7 +110,7 @@ pub fn encode_input(
     cur = encode(&tx.version, cur, &mut ret, piece_len);
     cur = encode(&varint(tx.input.len()), cur, &mut ret, piece_len);
     for (n, input) in tx.input.iter().enumerate() {
-        let dummy = bitcoin::Script::new();
+        let dummy = bitcoin::ScriptBuf::new();
         let spk = if n == index {
             &trusted_inputs[n].script_pubkey
         } else {

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     #[error("incorrect sequence no for APDU (expected {expected:?}, found {found:?})")]
     ApduWrongSequence { expected: u16, found: u16 },
     #[error("bitcoin")]
-    Bitcoin(#[from] bitcoin::key::Error),
+    Bitcoin(#[from] bitcoin::key::ParsePublicKeyError),
     #[error("no dongle detected")]
     DongleNotFound,
     #[error("more than one dongle detected")]

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     #[error("incorrect sequence no for APDU (expected {expected:?}, found {found:?})")]
     ApduWrongSequence { expected: u16, found: u16 },
     #[error("bitcoin")]
-    Bitcoin(#[from] bitcoin::util::key::Error),
+    Bitcoin(#[from] bitcoin::key::Error),
     #[error("no dongle detected")]
     DongleNotFound,
     #[error("more than one dongle detected")]
@@ -47,8 +47,8 @@ pub enum Error {
     Miniscript(#[from] miniscript::Error),
     #[error("not our key (fingerprint {key_fingerprint} vs our fingerprint {our_fingerprint})")]
     NotOurKey {
-        our_fingerprint: bitcoin::util::bip32::Fingerprint,
-        key_fingerprint: bitcoin::util::bip32::Fingerprint,
+        our_fingerprint: bitcoin::bip32::Fingerprint,
+        key_fingerprint: bitcoin::bip32::Fingerprint,
     },
     #[error("hidapi")]
     Hid(#[from] hidapi::HidError),

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -56,7 +56,7 @@ pub mod hid {
 /// Opaque cache of keys we've queried a dongle for
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct KeyCache {
-    map: HashMap<bip32::ExtendedPubKey, HashMap<bip32::DerivationPath, secp256k1::PublicKey>>,
+    map: HashMap<bip32::Xpub, HashMap<bip32::DerivationPath, secp256k1::PublicKey>>,
 }
 
 impl KeyCache {
@@ -83,7 +83,7 @@ impl KeyCache {
     /// Looks up a key in the map
     fn lookup(
         &self,
-        xpub: bip32::ExtendedPubKey,
+        xpub: bip32::Xpub,
         path: &bip32::DerivationPath,
     ) -> Option<secp256k1::PublicKey> {
         self.map.get(&xpub).and_then(|map| map.get(path)).copied()
@@ -92,7 +92,7 @@ impl KeyCache {
     /// Adds a key to the map
     fn insert(
         &mut self,
-        xpub: bip32::ExtendedPubKey,
+        xpub: bip32::Xpub,
         path: bip32::DerivationPath,
         key: secp256k1::PublicKey,
     ) {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -34,7 +34,7 @@ mod error;
 mod util;
 mod wallet;
 
-use miniscript::bitcoin::{secp256k1, util::bip32};
+use miniscript::bitcoin::{bip32, secp256k1};
 use miniscript::DescriptorPublicKey;
 use std::collections::HashMap;
 
@@ -70,13 +70,13 @@ impl KeyCache {
         &self,
         d: &miniscript::DefiniteDescriptorKey,
     ) -> Option<secp256k1::PublicKey> {
-        let d: DescriptorPublicKey = d.clone().into(); // FIXME https://github.com/rust-bitcoin/rust-miniscript/pull/492
-        match d {
+        match *d.as_descriptor_public_key() {
             DescriptorPublicKey::Single(ref single) => match single.key {
                 miniscript::descriptor::SinglePubKey::FullKey(key) => Some(key.inner),
                 miniscript::descriptor::SinglePubKey::XOnly(_) => todo!("No taproot support yet"),
             },
             DescriptorPublicKey::XPub(ref xpub) => self.lookup(xpub.xkey, &xpub.derivation_path),
+            DescriptorPublicKey::MultiXPub(..) => panic!("multi-xpubs (BIP 389) not supported"),
         }
     }
 

--- a/src/lib/wallet/address.rs
+++ b/src/lib/wallet/address.rs
@@ -39,11 +39,14 @@ pub struct Address {
 
 impl Address {
     /// If this address is a p2pkh address or p2wpkh, the derivation path to it
-    pub fn change_path(&self) -> Option<bitcoin::util::bip32::DerivationPath> {
+    pub fn change_path(&self) -> Option<bitcoin::bip32::DerivationPath> {
         match self.instantiated_descriptor {
-            miniscript::Descriptor::Pkh(ref pkh) => {
-                Some(pkh.as_inner().desc_key.full_derivation_path())
-            }
+            miniscript::Descriptor::Pkh(ref pkh) => Some(
+                pkh.as_inner()
+                    .desc_key
+                    .full_derivation_path()
+                    .expect("no multipath keys"),
+            ),
             _ => None,
         }
     }

--- a/src/lib/wallet/encode/crypt.rs
+++ b/src/lib/wallet/encode/crypt.rs
@@ -55,8 +55,8 @@ impl<R: Read + Seek> CryptReader<R> {
         let tag = sha256::Hash::hash(b"icboc3d/wallet");
         let mut hmac_eng = HmacEngine::<sha256::Hash>::new(&key);
 
-        hmac_eng.input(&tag);
-        hmac_eng.input(&tag);
+        hmac_eng.input(tag.as_byte_array());
+        hmac_eng.input(tag.as_byte_array());
 
         let mut magic = [0; 4];
         r.read_exact(&mut magic)?;
@@ -98,7 +98,7 @@ impl<R: Read + Seek> CryptReader<R> {
 
         let mut hmac_read = [0; 32];
         r.read_exact(&mut hmac_read)?;
-        let hmac_read = Hmac::<sha256::Hash>::from_inner(hmac_read);
+        let hmac_read = Hmac::<sha256::Hash>::from_byte_array(hmac_read);
         let hmac_computed = Hmac::<sha256::Hash>::from_engine(hmac_eng);
         if hmac_read != hmac_computed {
             return Err(io::Error::new(
@@ -172,8 +172,8 @@ impl<W: io::Write> CryptWriter<W> {
         self.writer.write_all(&MAGIC_BYTES[..])?;
         self.writer.write_all(&self.nonce[..])?;
 
-        self.hmac_eng.input(&tag);
-        self.hmac_eng.input(&tag);
+        self.hmac_eng.input(tag.as_byte_array());
+        self.hmac_eng.input(tag.as_byte_array());
         self.hmac_eng.input(&MAGIC_BYTES[..]);
         self.hmac_eng.input(&self.nonce[..]);
 

--- a/src/lib/wallet/encode/mod.rs
+++ b/src/lib/wallet/encode/mod.rs
@@ -153,7 +153,7 @@ pub struct EncTxo {
     /// Outpoint of the TXO
     pub outpoint: bitcoin::OutPoint,
     /// Value of the TXO, in satoshis
-    pub value: u64,
+    pub value: bitcoin::Amount,
     /// If the TXO is spent, the txid that spent it
     pub spent: Option<bitcoin::Txid>,
     /// Blockheight at which the UTXO was created

--- a/src/lib/wallet/encode/serialize.rs
+++ b/src/lib/wallet/encode/serialize.rs
@@ -17,7 +17,7 @@
 //! Data types which can be read and written to the wallet backing store
 //!
 
-use miniscript::bitcoin::{self, secp256k1, util::bip32};
+use miniscript::bitcoin::{self, bip32, secp256k1};
 use std::io::{self, Read, Write};
 use std::str::FromStr;
 
@@ -227,7 +227,7 @@ impl Serialize for miniscript::Descriptor<miniscript::DescriptorPublicKey> {
     }
 }
 
-impl Serialize for bitcoin::Script {
+impl Serialize for bitcoin::ScriptBuf {
     fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
         let len32: u32 = self.len() as u32;
         if self.len() > MAX_SCRIPTPUBKEY_SIZE as usize {
@@ -261,7 +261,7 @@ impl Serialize for bitcoin::Script {
         }
 
         r.read_exact(&mut ret)?;
-        Ok(bitcoin::Script::from(ret))
+        Ok(bitcoin::ScriptBuf::from(ret))
     }
 }
 

--- a/src/lib/wallet/encode/serialize.rs
+++ b/src/lib/wallet/encode/serialize.rs
@@ -17,7 +17,7 @@
 //! Data types which can be read and written to the wallet backing store
 //!
 
-use miniscript::bitcoin::{self, hashes::Hash, secp256k1, util::bip32};
+use miniscript::bitcoin::{self, secp256k1, util::bip32};
 use std::io::{self, Read, Write};
 use std::str::FromStr;
 
@@ -39,90 +39,45 @@ pub trait Serialize: Sized {
     fn read_from<R: Read>(r: R) -> io::Result<Self>;
 }
 
-impl Serialize for u8 {
-    fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
-        w.write_all(&[*self])
-    }
+macro_rules! impl_int {
+    ($itype:ty) => {
+        impl Serialize for $itype {
+            fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
+                w.write_all(&self.to_le_bytes())
+            }
 
-    fn read_from<R: Read>(mut r: R) -> io::Result<Self> {
-        let mut dat = [0; 1];
-        r.read_exact(&mut dat)?;
-        Ok(dat[0])
-    }
+            fn read_from<R: Read>(mut r: R) -> io::Result<Self> {
+                let mut dat = [0; core::mem::size_of::<$itype>()];
+                r.read_exact(&mut dat)?;
+                Ok(<$itype>::from_le_bytes(dat))
+            }
+        }
+    };
 }
 
-impl Serialize for u32 {
-    fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
-        w.write_all(&[
-            *self as u8,
-            (*self >> 8) as u8,
-            (*self >> 16) as u8,
-            (*self >> 24) as u8,
-        ])
-    }
+impl_int!(u8);
+impl_int!(u16);
+impl_int!(u32);
+impl_int!(u64);
 
-    fn read_from<R: Read>(mut r: R) -> io::Result<Self> {
-        let mut dat = [0; 4];
-        r.read_exact(&mut dat)?;
-        Ok(u32::from(dat[0])
-            + (u32::from(dat[1]) << 8)
-            + (u32::from(dat[2]) << 16)
-            + (u32::from(dat[3]) << 24))
-    }
+macro_rules! impl_bitcoin_consensus {
+    ($itype:ty) => {
+        impl Serialize for $itype {
+            fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
+                bitcoin::consensus::Encodable::consensus_encode(self, &mut w).map(|_| ())
+            }
+
+            fn read_from<R: Read>(mut r: R) -> io::Result<Self> {
+                bitcoin::consensus::Decodable::consensus_decode(&mut r)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+            }
+        }
+    };
 }
 
-impl Serialize for u64 {
-    fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
-        (*self as u32).write_to(&mut w)?;
-        ((*self >> 32) as u32).write_to(w)
-    }
-
-    fn read_from<R: Read>(mut r: R) -> io::Result<Self> {
-        let lo: u32 = Serialize::read_from(&mut r)?;
-        let hi: u32 = Serialize::read_from(r)?;
-        Ok((u64::from(lo)) + ((u64::from(hi)) << 32))
-    }
-}
-
-impl Serialize for miniscript::bitcoin::Txid {
-    fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
-        w.write_all(self)
-    }
-
-    fn read_from<R: Read>(mut r: R) -> io::Result<Self> {
-        let mut dat = [0; 32];
-        r.read_exact(&mut dat)?;
-        Ok(miniscript::bitcoin::Txid::from_inner(dat))
-    }
-}
-
-impl Serialize for miniscript::bitcoin::OutPoint {
-    fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
-        self.txid.write_to(&mut w)?;
-        self.vout.write_to(w)
-    }
-
-    fn read_from<R: Read>(mut r: R) -> io::Result<Self> {
-        Ok(miniscript::bitcoin::OutPoint {
-            txid: Serialize::read_from(&mut r)?,
-            vout: Serialize::read_from(r)?,
-        })
-    }
-}
-
-impl Serialize for miniscript::bitcoin::Transaction {
-    fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
-        // FIXME a later version of rust-bitcoin will just directly return io::Errors here
-        bitcoin::consensus::Encodable::consensus_encode(self, &mut w)
-            .map(|_| ())
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-    }
-
-    fn read_from<R: Read>(mut r: R) -> io::Result<Self> {
-        bitcoin::consensus::Decodable::consensus_decode(&mut r)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-    }
-}
+impl_bitcoin_consensus!(bitcoin::OutPoint);
+impl_bitcoin_consensus!(bitcoin::Transaction);
+impl_bitcoin_consensus!(bitcoin::Txid);
 
 impl<T: Serialize> Serialize for Vec<T> {
     fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {

--- a/src/lib/wallet/encode/serialize.rs
+++ b/src/lib/wallet/encode/serialize.rs
@@ -75,6 +75,7 @@ macro_rules! impl_bitcoin_consensus {
     };
 }
 
+impl_bitcoin_consensus!(bitcoin::Amount);
 impl_bitcoin_consensus!(bitcoin::OutPoint);
 impl_bitcoin_consensus!(bitcoin::Transaction);
 impl_bitcoin_consensus!(bitcoin::Txid);
@@ -172,7 +173,7 @@ impl Serialize for secp256k1::PublicKey {
     }
 }
 
-impl Serialize for bip32::ExtendedPubKey {
+impl Serialize for bip32::Xpub {
     fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
         w.write_all(&self.encode())
     }
@@ -180,8 +181,7 @@ impl Serialize for bip32::ExtendedPubKey {
     fn read_from<R: Read>(mut r: R) -> io::Result<Self> {
         let mut data = [0; 78];
         r.read_exact(&mut data[..])?;
-        bip32::ExtendedPubKey::decode(&data[..])
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        bip32::Xpub::decode(&data[..]).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 }
 

--- a/src/lib/wallet/mod.rs
+++ b/src/lib/wallet/mod.rs
@@ -87,7 +87,7 @@ impl Wallet {
             tx_cache: enc_wallet
                 .tx_cache
                 .into_iter()
-                .map(|tx| (tx.txid(), tx))
+                .map(|tx| (tx.compute_txid(), tx))
                 .collect(),
         };
         // Copy descriptors into arcs
@@ -412,7 +412,7 @@ impl Wallet {
 
         for (vout, output) in tx.output.iter().enumerate() {
             if let Some(addr) = self.spk_address.get(&output.script_pubkey) {
-                let outpoint = bitcoin::OutPoint::new(tx.txid(), vout as u32);
+                let outpoint = bitcoin::OutPoint::new(tx.compute_txid(), vout as u32);
                 match self.txos.entry(outpoint) {
                     Entry::Vacant(v) => {
                         v.insert(Txo {
@@ -425,7 +425,7 @@ impl Wallet {
                     }
                     Entry::Occupied(mut o) => o.get_mut().height = height,
                 }
-                self.tx_cache.insert(tx.txid(), tx.clone());
+                self.tx_cache.insert(tx.compute_txid(), tx.clone());
                 received.insert(outpoint);
             }
         }
@@ -436,12 +436,12 @@ impl Wallet {
                     println!(
                         "Warning: {} is double-spent by {} (original transaction {})",
                         input.previous_output,
-                        tx.txid(),
+                        tx.compute_txid(),
                         data.txid,
                     );
                 }
                 txo.spent_data = Some(SpentData {
-                    txid: tx.txid(),
+                    txid: tx.compute_txid(),
                     height,
                 });
                 spent.insert(input.previous_output);

--- a/src/lib/wallet/txo.rs
+++ b/src/lib/wallet/txo.rs
@@ -28,7 +28,7 @@ pub struct Txo {
     /// Outpoint of the TXO
     pub outpoint: bitcoin::OutPoint,
     /// Value of the TXO, in satoshis
-    pub value: u64,
+    pub value: bitcoin::Amount,
     /// Blockheight at which the UTXO was created. Can be changed
     /// when rescanning in case of reorg
     pub height: u64,
@@ -76,7 +76,7 @@ impl fmt::Display for Txo {
             f,
             "{{ outpoint: \"{}\", value: \"{}\", height: {}, address: \"{}\", descriptor: \"{}\", index: {}",
             self.outpoint,
-            bitcoin::Amount::from_sat(self.value),
+            self.value,
             self.height,
             address,
             self.address.descriptor.desc,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -36,18 +36,18 @@ impl Bitcoind {
 
     /// Get the number of blocks the bitcoind is aware of
     pub fn getblockcount(&self) -> anyhow::Result<u64> {
-        Ok(self.rpc_client.call("getblockcount", &[])?)
+        Ok(self.rpc_client.call("getblockcount", None)?)
     }
 
     /// Get a block at a specified height
     pub fn getblock(&self, index: u64) -> anyhow::Result<bitcoin::Block> {
         let hash: sha256d::Hash = self
             .rpc_client
-            .call("getblockhash", &[arg(index)])
+            .call("getblockhash", Some(&arg([index])))
             .with_context(|| format!("getting hash of block {}", index))?;
         let hex: String = self
             .rpc_client
-            .call("getblock", &[arg(hash), arg(0)])
+            .call("getblock", Some(&arg((hash, 0))))
             .with_context(|| format!("getting hex of block {} ({})", index, hash))?;
         let bytes: Vec<u8> = hex::FromHex::from_hex(&hex)
             .with_context(|| format!("deserializing hex of block {} ({})", index, hash))?;


### PR DESCRIPTION
Also does some general type-safety improvements, drops the `byteorder` dep entirely, removes the `home` dependency when jsonrpc is off (since it's only used to find the bitcoin RPC cookie), eliminates a bunch of `unwraps` and casts, and replaces a bunch of manual endian-conversion code with calls into stdlib.