### PR TITLE
getnewaddress displays address on device

### DIFF
--- a/src/commands/getnewaddress.rs
+++ b/src/commands/getnewaddress.rs
@@ -61,7 +61,7 @@ impl super::Command for GetNewAddress {
 
         // FIXME should notice/warn when overwriting an existing address
         let addr = wallet
-            .add_address(options.descriptor, options.index, timestr, options.note)
+            .add_address(options.descriptor, options.index, timestr, options.note, dongle, true)
             .context("adding address")?;
 
         println!("{}", addr);

--- a/src/commands/importicboc/mod.rs
+++ b/src/commands/importicboc/mod.rs
@@ -148,7 +148,7 @@ impl super::Command for ImportIcboc {
                         .with_context(|| format!("decoding notes from entry {}", i))?
                 };
                 wallet
-                    .add_address(desc_idx, Some(i as u32), time, notes)
+                    .add_address(desc_idx, Some(i as u32), time, notes, dongle, false)
                     .with_context(|| format!("importing address for entry {}", i))?;
             }
 

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -35,7 +35,6 @@ mod util;
 mod wallet;
 
 use miniscript::bitcoin::{bip32, secp256k1};
-use miniscript::DescriptorPublicKey;
 use std::collections::HashMap;
 
 pub use dongle::ledger;
@@ -63,21 +62,6 @@ impl KeyCache {
     /// Construct a new empty key cache
     fn new() -> Self {
         Self::default()
-    }
-
-    /// Looks up a descriptor public key in the cache.
-    fn lookup_descriptor_pubkey(
-        &self,
-        d: &miniscript::DefiniteDescriptorKey,
-    ) -> Option<secp256k1::PublicKey> {
-        match *d.as_descriptor_public_key() {
-            DescriptorPublicKey::Single(ref single) => match single.key {
-                miniscript::descriptor::SinglePubKey::FullKey(key) => Some(key.inner),
-                miniscript::descriptor::SinglePubKey::XOnly(_) => todo!("No taproot support yet"),
-            },
-            DescriptorPublicKey::XPub(ref xpub) => self.lookup(xpub.xkey, &xpub.derivation_path),
-            DescriptorPublicKey::MultiXPub(..) => panic!("multi-xpubs (BIP 389) not supported"),
-        }
     }
 
     /// Looks up a key in the map


### PR DESCRIPTION
TBH, I don't think we should merge this, but you might want to take a look and comment on it.

I think it would be better to make some sort of `UncachedKeyTranslator` and/or an explicit `displayaddress` command to display the address of one index on the ledger via a direct call to `GetWalletPublicKey`.